### PR TITLE
Handle Cholesky decomposition errors in estimate_prior

### DIFF
--- a/R/estimate_prior.R
+++ b/R/estimate_prior.R
@@ -1205,15 +1205,19 @@ estimate_prior <- function(
                                Chol_svd = Chol_svd,
                                pivots = pivots) #need to use these along with FC_samp_cholinv to determine inv(FC)
     } #end Cholesky-based FC prior estimation
-    mean_failures_per_failed_pivot <- if (length(pivot_failures) > 0) {
-      mean(pivot_failures)
+    if (length(pivot_failures) > 0) {
+      mean_failures_per_failed_pivot <- mean(pivot_failures)
+      min_failures_per_failed_pivot <- min(pivot_failures)
+      max_failures_per_failed_pivot <- max(pivot_failures) 
     } else {
-      0
+      mean_failures_per_failed_pivot <- 0
+      min_failures_per_failed_pivot <- 0
+      max_failures_per_failed_pivot <- 0
     }
     if (verbose) {
       cat("\n--- Cholesky Error Summary ---\n")
       cat("Number of pivots with any failures:", count_pivot_fails, "/", FC_nPivots, "\n")
-      cat("Average failures per failed pivot:", round(mean_failures_per_failed_pivot, 2), "\n")
+      cat("Failures per failed pivot — mean:", mean_failures_per_failed_pivot, "| range:", min_failures_per_failed_pivot, "to", max_failures_per_failed_pivot, "\n")
     }
   }
 

--- a/R/estimate_prior.R
+++ b/R/estimate_prior.R
@@ -1131,6 +1131,9 @@ estimate_prior <- function(
           # a) log|X| = 2*sum(log(diag(L))), where L is the upper or lower triangular Cholesky matrix
           # b) a'X^(-1)a can be written b'b, where b = R_p^(-T)*P*a, where R_p is the upper triangular Cholesky matrix
       for(pp in 1:FC_nPivots){
+        # count errors in chol
+        counter_env <- new.env()
+        counter_env$count <- 0
 
         #perform Cholesky decomposition on each matrix in FC0 --> dim(FC0) = c(nM, nN, nL, nL)
         Chol_p <- apply(FC0, 1:2, function(x, pivot){ # dim = nChol x nM x nN
@@ -1142,9 +1145,15 @@ estimate_prior <- function(
             chol_xp <- chol(xp)
             chol_xp[upper.tri(chol_xp, diag = TRUE)]
           }, error = function(e) {
+            counter_env$count <- counter_env$count + 1
             rep(NA_real_, length(xp[upper.tri(xp, diag = TRUE)]))
           })
         }, pivot = pivots[[pp]])
+
+        if (verbose) { 
+          cat("\nFailed for", pp, "#", counter_env$count, "\n") 
+        }
+
         #rbind across sessions to form a matrix
         Chol_mat_p <- rbind(t(Chol_p[,1,]), t(Chol_p[,2,])) # dim = nM*nN x nChol
         ## NOHELIA


### PR DESCRIPTION
Wrapped the Cholesky decomposition step in a tryCatch to handle errors caused by rank-deficient matrices or NA values in FC0. If an error occurs, the corresponding output is replaced with NA values. These NA rows are then removed before downstream sampling to ensure stability.

Added logic to:
- Track the number of failures per pivot
- Count how many pivots failed at least once
- Report an error summary (mean and range of failures per failed pivot) when verbose = TRUE
