### PR TITLE
Bug fixes for usePar and scrub use cases

### DIFF
--- a/R/estimate_prior.R
+++ b/R/estimate_prior.R
@@ -748,6 +748,9 @@ estimate_prior <- function(
     } else {
       cluster <- parallel::makeCluster(nCores, outfile="")
       doParallel::registerDoParallel(cluster)
+      parallel::clusterEvalQ(cluster, {
+        .libPaths(sys.getenv("R_LIBS_USER"))
+      })
     }
   }
 

--- a/R/estimate_prior.R
+++ b/R/estimate_prior.R
@@ -749,7 +749,7 @@ estimate_prior <- function(
       cluster <- parallel::makeCluster(nCores, outfile="")
       doParallel::registerDoParallel(cluster)
       parallel::clusterEvalQ(cluster, {
-        .libPaths(sys.getenv("R_LIBS_USER"))
+        .libPaths(Sys.getenv("R_LIBS_USER"))
       })
     }
   }

--- a/R/fit_BBM.R
+++ b/R/fit_BBM.R
@@ -319,8 +319,8 @@ fit_BBM <- function(
     scale <- "global"
   }
   stopifnot(is_1(scale_sm_FWHM, "numeric"))
-  if (is.list(nuisance)) { stopifnot(length(nuisance)==nN) }
-  if (is.list(scrub)) { stopifnot(length(scrub)==nN) }
+  #if (is.list(nuisance)) { stopifnot(length(nuisance)==nN) }
+  #if (is.list(scrub)) { stopifnot(length(scrub)==nN) }
   stopifnot(is_1(drop_first, "numeric") && drop_first==round(drop_first))
   if (TR!= "from_xifti_metadata") { stopifnot(fMRItools::is_posNum(TR)) }
   stopifnot(fMRItools::is_posNum(hpf, zero_ok=TRUE))
@@ -357,8 +357,12 @@ fit_BBM <- function(
     if (nCores < 2) {
       usePar <- FALSE
     } else {
-      #cluster <- parallel::makeCluster(nCores)
-      doParallel::registerDoParallel(nCores)
+      cluster <- parallel::makeCluster(nCores)
+      #doParallel::registerDoParallel(nCores)
+      # Evaluate user libraries to each thread through the environment variables.
+      parallel::clusterEvalQ(cluster, {
+        .libPaths(sys.getenv("R_LIBS_USER"))
+      })
     }
   }
 

--- a/R/fit_BBM.R
+++ b/R/fit_BBM.R
@@ -361,7 +361,7 @@ fit_BBM <- function(
       #doParallel::registerDoParallel(nCores)
       # Evaluate user libraries to each thread through the environment variables.
       parallel::clusterEvalQ(cluster, {
-        .libPaths(sys.getenv("R_LIBS_USER"))
+        .libPaths(Sys.getenv("R_LIBS_USER"))
       })
     }
   }


### PR DESCRIPTION
Each thread's `libPath()` is set to the library environment variable.

The sanity check for the length of `scrub` and `nuisance` is omitted since it occurs before the length of the BOLD is defined.
