### PR TITLE
doParallel library required even when usePar=FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesBrainMap
 Type: Package
 Title: Estimate Brain Networks and Connectivity with Population-Derived Priors
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: c(
     person(given = "Amanda",
            family = "Mejia",

--- a/R/fit_BBM.R
+++ b/R/fit_BBM.R
@@ -1109,8 +1109,8 @@ fit_BBM <- function(
 
     #no parallelization implemented for VB1
     if(method_FC=='VB1') {
+      if (usePar) { doParallel::stopImplicitCluster() }
       usePar <- FALSE
-      doParallel::stopImplicitCluster()
     }
 
     result <- VB_FC_BBM(


### PR DESCRIPTION
When `method_FC="VB1"`, `fit_BBM()` reverts to not using parallel computing, as it is not implemented. However, it tries to stop a cluster even if `usePar=FALSE', resulting in an error if the package is not installed.

This is fixed by checking `usePar` before stopping the cluster.